### PR TITLE
bugfix: fix arms_search_apps wrong return type

### DIFF
--- a/src/mcp_server_aliyun_observability/toolkit/arms_toolkit.py
+++ b/src/mcp_server_aliyun_observability/toolkit/arms_toolkit.py
@@ -41,7 +41,7 @@ class ArmsToolkit:
                 20, description="page size,max is 100", ge=1, le=100
             ),
             pageNumber: int = Field(1, description="page number,default is 1", ge=1),
-        ) -> list[dict[str, Any]]:
+        ) -> dict[str, Any]:
             """搜索ARMS应用。
 
             ## 功能概述


### PR DESCRIPTION
arms_search_apps 函数中定义的返回值类型和真实的类型不同，造成执行错误。错误如下：
```
Error executing tool arms_search_apps: 
1 validation error for arms_search_appsOutput
result
  Input should be a valid list [type=list_type, input_value={'total': 1, 'page_size':...126', 'type': 'TRACE'}]}, input_type=dict]
```

具体原因是真实返回的是 dict，而函数定义的是 list，修复后工具调用正常。