### PR TITLE
feat(sls): sls_execute_sql 新增 offset/reverse 分页参数 & 完善测试框架

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # 版本更新
 
+## 1.0.5 (2026-01-13)
+### 新功能
+- `sls_execute_sql` 工具新增分页查询支持
+  - 新增 `offset` 参数：查询开始行，用于分页查询，默认 0
+  - 新增 `reverse` 参数：是否按日志时间戳降序返回，默认 False
+  - 支持获取超过 100 条的完整日志数据（通过多次分页调用）
+  - 完全向后兼容，新参数均为可选且有默认值
+
+### 测试改进
+- 新增 SLS 集成测试框架，支持测试环境自动创建和销毁
+  - 新增 `conftest.py`：自动创建/销毁 Project、Logstore、索引和测试数据
+  - 新增 `test_iaas_integration.py`：分页查询、排序、向后兼容性等集成测试
+- 为所有需要真实凭证的测试添加 `@pytest.mark.integration` 标记
+  - 无凭证环境下自动跳过集成测试，不影响 CI 流水线
+- `pytest.ini` 新增 `integration` marker 定义
+
+### 文档更新
+- 完善 `CONTRIBUTION.md` 测试指引
+  - 新增测试分类说明（单元测试 vs 集成测试）
+  - 新增环境准备和测试命令文档
+  - 新增 PR 提交检查清单
+  - 新增测试用例编写示例和目录结构说明
+
 ## 1.0.4 (2025-12-26)
 ### 修复
 - `umodel_get_relation_metrics` 工具修复 `get_relation_metric` 查询参数错误

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Observable MCP Server 现已支持日志服务 SLS、应用实时监控服务 AR
 |---------|------|---------|---------|  
 | `cms_text_to_promql` | 将自然语言转换为PromQL查询 | `text`：自然语言问题（必需）<br>`project`：项目名称（必需）<br>`metricStore`：指标存储名称（必需）<br>`regionId`：阿里云区域ID（必需） | - 智能生成PromQL语句<br>- 简化查询操作 |
 | `sls_text_to_sql` | 将自然语言转换为SQL查询 | `text`：自然语言问题（必需）<br>`project`：SLS项目名称（必需）<br>`logStore`：日志存储名称（必需）<br>`regionId`：阿里云区域ID（必需） | - 智能生成SLS SQL查询<br>- 支持自然语言交互 |
-| `sls_execute_sql` | 执行SLS SQL查询 | `project`：SLS项目名称（必需）<br>`logStore`：日志存储名称（必需）<br>`query`：SQL查询语句（必需）<br>`from_time`：查询开始时间（必需）<br>`to_time`：查询结束时间（必需）<br>`regionId`：阿里云区域ID（必需） | - 直接执行SQL查询<br>- 使用适当时间范围优化性能 |
+| `sls_execute_sql` | 执行SLS SQL查询 | `project`：SLS项目名称（必需）<br>`logStore`：日志存储名称（必需）<br>`query`：SQL查询语句（必需）<br>`from_time`：查询开始时间（必需）<br>`to_time`：查询结束时间（必需）<br>`limit`：返回最大日志条数，1-100，默认10（可选）<br>`offset`：查询开始行，用于分页，默认0（可选）<br>`reverse`：是否按时间戳降序返回，默认False（可选）<br>`regionId`：阿里云区域ID（必需） | - 直接执行SQL查询<br>- 使用适当时间范围优化性能<br>- 支持分页查询获取更多日志 |
 | `cms_execute_promql` | 执行PromQL查询 | `project`：项目名称（必需）<br>`metricStore`：指标存储名称（必需）<br>`query`：PromQL查询语句（必需）<br>`start_time`：查询开始时间（必需）<br>`end_time`：查询结束时间（必需）<br>`regionId`：阿里云区域ID（必需） | - 查询云监控指标数据<br>- 支持标准PromQL语法 |
 | `sls_list_projects` | 列出SLS项目 | `projectName`：项目名称（可选，模糊搜索）<br>`regionId`：阿里云区域ID（必需） | - 发现可用的SLS项目<br>- 支持模糊搜索 |
 | `sls_execute_spl` | 执行原生SPL查询 | `query`：SPL查询语句（必需）<br>`regionId`：阿里云区域ID（必需） | - 执行复杂的SLS查询<br>- 支持高级分析功能 |

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
 asyncio_default_fixture_loop_scope = function
+asyncio_mode = auto
+markers =
+    integration: 集成测试，需要真实阿里云环境（需设置 ALIBABA_CLOUD_ACCESS_KEY_ID 和 ALIBABA_CLOUD_ACCESS_KEY_SECRET）

--- a/src/mcp_server_aliyun_observability/toolkits/iaas/toolkit.py
+++ b/src/mcp_server_aliyun_observability/toolkits/iaas/toolkit.py
@@ -224,6 +224,15 @@ class IaaSToolkit:
                 description="to time,support unix timestamp or relative time like 'now'",
             ),
             limit: int = Field(10, description="limit,max is 100", ge=1, le=100),
+            offset: int = Field(
+                0,
+                description="query start offset for pagination, default is 0. Only effective when query is a search statement (not SQL analytics)",
+                ge=0,
+            ),
+            reverse: bool = Field(
+                False,
+                description="whether to return logs in descending order by timestamp, default is False. Only effective when query is a search statement",
+            ),
             regionId: str = Field(
                 default=...,
                 description="aliyun region id,region id format like 'xx-xxx',like 'cn-hangzhou'",
@@ -268,6 +277,8 @@ class IaaSToolkit:
                 from_time: 查询开始时间，支持时间戳或相对时间
                 to_time: 查询结束时间，支持时间戳或相对时间
                 limit: 返回结果的最大数量，范围1-100，默认10
+                offset: 查询开始行，用于分页查询，默认0。仅在query为纯查询语句时有效
+                reverse: 是否按日志时间戳降序返回，默认False。仅在query为纯查询语句时有效
                 regionId: 阿里云区域ID
 
             Returns:
@@ -290,6 +301,8 @@ class IaaSToolkit:
                 from_=from_timestamp,
                 to=to_timestamp,
                 line=limit,
+                offset=offset,
+                reverse=reverse,
             )
 
             runtime: util_models.RuntimeOptions = util_models.RuntimeOptions()

--- a/tests/mcp_server_aliyun_observability/toolkits/iaas/conftest.py
+++ b/tests/mcp_server_aliyun_observability/toolkits/iaas/conftest.py
@@ -1,0 +1,391 @@
+"""IaaS Toolkit 测试环境配置
+
+提供真实 SLS 测试环境的 setup 和 teardown 闭环：
+- 自动创建测试用的 Project 和 Logstore
+- 写入测试日志数据
+- 测试完成后自动清理资源
+"""
+import os
+import time
+import uuid
+from typing import Generator
+
+import dotenv
+import pytest
+from alibabacloud_sls20201230.client import Client as SLSClient
+from alibabacloud_sls20201230.models import (
+    CreateLogStoreRequest,
+    CreateProjectRequest,
+    CreateIndexRequest,
+    DeleteProjectRequest,
+    Index,
+    IndexLine,
+    IndexKey,
+    PutLogsRequest,
+    PutLogsHeaders,
+    LogGroup,
+    LogItem,
+    LogContent,
+)
+from alibabacloud_tea_openapi import models as open_api_models
+from alibabacloud_tea_util import models as util_models
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.shared.context import RequestContext
+
+from mcp_server_aliyun_observability.server import create_lifespan
+from mcp_server_aliyun_observability.toolkits.iaas.toolkit import register_iaas_tools
+from mcp_server_aliyun_observability.utils import SLSClientWrapper, CredentialWrapper
+from mcp_server_aliyun_observability.logger import get_logger
+
+# 加载环境变量
+dotenv.load_dotenv()
+
+logger = get_logger()
+
+
+class SLSTestEnvironment:
+    """SLS 测试环境管理器
+    
+    负责创建和销毁测试用的 SLS 资源，包括：
+    - Project
+    - Logstore
+    - 索引配置
+    - 测试日志数据
+    """
+    
+    def __init__(
+        self,
+        region_id: str = "cn-hangzhou",
+        project_prefix: str = "mcp-test",
+        logstore_name: str = "test-logs",
+    ):
+        self.region_id = region_id
+        self.project_prefix = project_prefix
+        self.logstore_name = logstore_name
+        
+        # 生成唯一的项目名称（避免冲突）
+        unique_id = uuid.uuid4().hex[:8]
+        self.project_name = f"{project_prefix}-{unique_id}"
+        
+        # 从环境变量获取凭证
+        self.access_key_id = os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID")
+        self.access_key_secret = os.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET")
+        
+        if not self.access_key_id or not self.access_key_secret:
+            raise ValueError(
+                "请设置环境变量 ALIBABA_CLOUD_ACCESS_KEY_ID 和 ALIBABA_CLOUD_ACCESS_KEY_SECRET"
+            )
+        
+        # 打印调试信息（隐藏敏感信息）
+        masked_key_id = self.access_key_id[:4] + "****" + self.access_key_id[-4:] if len(self.access_key_id) > 8 else "****"
+        logger.info(f"使用 Access Key ID: {masked_key_id}, Region: {region_id}")
+        
+        # 创建 SLS 客户端
+        self.client = self._create_client()
+        
+        # 资源创建状态
+        self._project_created = False
+        self._logstore_created = False
+        self._index_created = False
+        
+    def _create_client(self) -> SLSClient:
+        """创建 SLS 客户端"""
+        config = open_api_models.Config(
+            access_key_id=self.access_key_id,
+            access_key_secret=self.access_key_secret,
+            endpoint=f"{self.region_id}.log.aliyuncs.com",
+        )
+        return SLSClient(config)
+    
+    def _get_runtime_options(self) -> util_models.RuntimeOptions:
+        """获取运行时选项"""
+        runtime = util_models.RuntimeOptions()
+        runtime.read_timeout = 60000
+        runtime.connect_timeout = 60000
+        return runtime
+    
+    def setup(self) -> dict:
+        """设置测试环境
+        
+        Returns:
+            包含测试环境信息的字典
+        """
+        logger.info(f"开始设置 SLS 测试环境: project={self.project_name}")
+        
+        try:
+            # 1. 创建 Project
+            self._create_project()
+            
+            # 等待 Project 创建完成
+            time.sleep(3)
+            
+            # 2. 创建 Logstore
+            self._create_logstore()
+            
+            # 等待 Logstore 创建完成
+            time.sleep(3)
+            
+            # 3. 创建索引
+            self._create_index()
+            
+            # 等待索引创建完成（SLS 索引创建需要较长时间才能生效）
+            logger.info("等待索引生效（约 30 秒）...")
+            time.sleep(30)
+            
+            # 4. 写入测试日志
+            self._put_test_logs()
+            
+            # 等待日志写入并可查询（日志服务有延迟）
+            logger.info("等待日志数据可查询（约 5 秒）...")
+            time.sleep(5)
+            
+            logger.info(f"SLS 测试环境设置完成: project={self.project_name}, logstore={self.logstore_name}")
+            
+            return {
+                "project": self.project_name,
+                "logstore": self.logstore_name,
+                "region_id": self.region_id,
+            }
+            
+        except Exception as e:
+            logger.error(f"设置测试环境失败: {e}")
+            # 尝试清理已创建的资源
+            self.teardown()
+            raise
+    
+    def _create_project(self):
+        """创建 SLS Project"""
+        logger.info(f"创建 Project: {self.project_name}")
+        
+        request = CreateProjectRequest(
+            project_name=self.project_name,
+            description="MCP Server Integration Test Project - Auto Created",
+        )
+        
+        self.client.create_project_with_options(
+            request, headers={}, runtime=self._get_runtime_options()
+        )
+        self._project_created = True
+        logger.info(f"Project 创建成功: {self.project_name}")
+    
+    def _create_logstore(self):
+        """创建 Logstore"""
+        logger.info(f"创建 Logstore: {self.logstore_name}")
+        
+        request = CreateLogStoreRequest(
+            logstore_name=self.logstore_name,
+            ttl=1,  # 保留 1 天
+            shard_count=2,  # 2 个 shard
+            auto_split=True,
+            max_split_shard=64,
+        )
+        
+        self.client.create_log_store_with_options(
+            self.project_name, request, headers={}, runtime=self._get_runtime_options()
+        )
+        self._logstore_created = True
+        logger.info(f"Logstore 创建成功: {self.logstore_name}")
+    
+    def _create_index(self):
+        """创建索引"""
+        logger.info(f"创建索引: {self.logstore_name}")
+        
+        # 通用分词符
+        default_token = [",", " ", "'", "\"", ";", "=", "(", ")", "[", "]", "{", "}", "?", "@", "&", "<", ">", "/", ":", "\n", "\t", "\r"]
+        
+        # 创建全文索引配置
+        line_config = IndexLine(
+            case_sensitive=False,
+            chn=True,  # 支持中文分词
+            token=default_token,
+        )
+        
+        # 创建字段索引配置（每个 IndexKey 都需要 token）
+        keys_config = {
+            "level": IndexKey(type="text", alias="", doc_value=True, case_sensitive=False, token=default_token),
+            "message": IndexKey(type="text", alias="", doc_value=True, case_sensitive=False, token=default_token),
+            "service": IndexKey(type="text", alias="", doc_value=True, case_sensitive=False, token=default_token),
+            "trace_id": IndexKey(type="text", alias="", doc_value=True, case_sensitive=False, token=default_token),
+            "request_id": IndexKey(type="text", alias="", doc_value=True, case_sensitive=False, token=default_token),
+        }
+        
+        # 创建 Index 对象
+        index_body = Index(
+            line=line_config,
+            keys=keys_config,
+        )
+        
+        request = CreateIndexRequest(body=index_body)
+        
+        self.client.create_index_with_options(
+            self.project_name, self.logstore_name, request, headers={}, runtime=self._get_runtime_options()
+        )
+        self._index_created = True
+        logger.info(f"索引创建成功: {self.logstore_name}")
+    
+    def _put_test_logs(self, count: int = 250):
+        """写入测试日志数据
+        
+        Args:
+            count: 写入的日志条数（默认 250 条，用于测试分页）
+        """
+        logger.info(f"写入测试日志: {count} 条")
+        
+        current_time = int(time.time())
+        
+        levels = ["INFO", "WARN", "ERROR", "DEBUG"]
+        services = ["user-service", "order-service", "payment-service", "gateway"]
+        
+        # 分批写入（每批最多 4096 条）
+        batch_size = 100
+        for batch_start in range(0, count, batch_size):
+            batch_end = min(batch_start + batch_size, count)
+            log_items = []
+            
+            for i in range(batch_start, batch_end):
+                level = levels[i % len(levels)]
+                service = services[i % len(services)]
+                
+                # 创建日志内容
+                contents = [
+                    LogContent(key="level", value=level),
+                    LogContent(key="message", value=f"Test log message {i}: This is a test log entry for pagination testing."),
+                    LogContent(key="service", value=service),
+                    LogContent(key="trace_id", value=f"trace-{uuid.uuid4().hex[:16]}"),
+                    LogContent(key="request_id", value=f"req-{i:06d}"),
+                ]
+                
+                # 创建日志条目
+                log_item = LogItem(
+                    contents=contents,
+                    time=current_time - (count - i),  # 按时间递增
+                )
+                log_items.append(log_item)
+            
+            # 创建日志组
+            log_group = LogGroup(
+                log_items=log_items,
+                source="mcp-integration-test",
+                topic="test",
+            )
+            
+            # 创建请求
+            request = PutLogsRequest(body=log_group)
+            
+            # 使用简单的 put_logs 方法（SDK 会自动处理压缩）
+            self.client.put_logs(
+                self.project_name,
+                self.logstore_name,
+                request,
+            )
+            logger.info(f"写入日志批次 {batch_start // batch_size + 1}: {batch_end - batch_start} 条")
+        
+        logger.info(f"测试日志写入完成: 共 {count} 条")
+    
+    def teardown(self):
+        """销毁测试环境"""
+        logger.info(f"开始清理 SLS 测试环境: project={self.project_name}")
+        
+        errors = []
+        
+        # 1. 删除 Logstore（必须先删除 Logstore 才能删除 Project）
+        if self._logstore_created:
+            try:
+                logger.info(f"删除 Logstore: {self.logstore_name}")
+                self.client.delete_log_store_with_options(
+                    self.project_name, self.logstore_name, headers={}, runtime=self._get_runtime_options()
+                )
+                logger.info(f"Logstore 删除成功: {self.logstore_name}")
+            except Exception as e:
+                logger.warning(f"删除 Logstore 失败: {e}")
+                errors.append(f"Logstore: {e}")
+        
+        # 等待 Logstore 删除完成
+        time.sleep(2)
+        
+        # 2. 删除 Project
+        if self._project_created:
+            try:
+                logger.info(f"删除 Project: {self.project_name}")
+                delete_request = DeleteProjectRequest()
+                self.client.delete_project_with_options(
+                    self.project_name, delete_request, headers={}, runtime=self._get_runtime_options()
+                )
+                logger.info(f"Project 删除成功: {self.project_name}")
+            except Exception as e:
+                logger.warning(f"删除 Project 失败: {e}")
+                errors.append(f"Project: {e}")
+        
+        if errors:
+            logger.warning(f"清理测试环境时遇到错误: {errors}")
+        else:
+            logger.info(f"SLS 测试环境清理完成: project={self.project_name}")
+
+
+@pytest.fixture(scope="module")
+def sls_test_env() -> Generator[dict, None, None]:
+    """SLS 测试环境 fixture（模块级别）
+    
+    自动创建和销毁 SLS 测试资源。
+    
+    Yields:
+        包含测试环境信息的字典：
+        - project: 项目名称
+        - logstore: 日志库名称
+        - region_id: 区域 ID
+    """
+    # 检查是否启用集成测试
+    if not os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"):
+        pytest.skip("未设置 ALIBABA_CLOUD_ACCESS_KEY_ID，跳过集成测试")
+    
+    env = SLSTestEnvironment(
+        region_id=os.getenv("SLS_TEST_REGION", "cn-hangzhou"),
+        project_prefix="mcp-test",
+        logstore_name="test-logs",
+    )
+    
+    try:
+        env_info = env.setup()
+        yield env_info
+    finally:
+        env.teardown()
+
+
+@pytest.fixture(scope="module")
+def real_request_context(sls_test_env: dict) -> Context:
+    """创建带有真实 SLS 客户端的请求上下文"""
+    return Context(
+        request_context=RequestContext(
+            request_id="integration_test_request",
+            meta=None,
+            session=None,
+            lifespan_context={
+                "cms_client": None,
+                "sls_client": SLSClientWrapper(
+                    credential=CredentialWrapper(
+                        access_key_id=os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+                        access_key_secret=os.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+                        knowledge_config=None,
+                    ),
+                ),
+                "arms_client": None,
+            },
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def real_mcp_server() -> FastMCP:
+    """创建带有 IaaS 工具的 FastMCP 服务器"""
+    server = FastMCP(
+        "integration-test-server",
+        lifespan=create_lifespan(
+            credential=CredentialWrapper(
+                access_key_id=os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+                access_key_secret=os.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+                knowledge_config=None,
+            ),
+        ),
+    )
+    register_iaas_tools(server)
+    return server

--- a/tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_integration.py
+++ b/tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_integration.py
@@ -1,0 +1,377 @@
+"""IaaS Toolkit 集成测试
+
+使用真实 SLS 环境测试工具包功能，包括：
+- 分页查询（offset 参数）
+- 排序控制（reverse 参数）
+- 向后兼容性验证
+"""
+import os
+import pytest
+from mcp.server.fastmcp import Context, FastMCP
+
+# 标记所有测试为集成测试
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+        reason="需要设置 ALIBABA_CLOUD_ACCESS_KEY_ID 环境变量"
+    ),
+]
+
+
+class TestSlsExecuteSqlIntegration:
+    """sls_execute_sql 接口集成测试"""
+    
+    @pytest.mark.asyncio
+    async def test_backward_compatible_without_new_params(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试向后兼容：不传 offset 和 reverse 参数"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None, "sls_execute_sql 工具未找到"
+        
+        # 使用旧的调用方式（不传 offset 和 reverse）
+        result = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "*",  # 纯查询语句
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 10,
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert "data" in result, f"响应缺少 data 字段: {result}"
+        assert "message" in result, f"响应缺少 message 字段: {result}"
+        assert result["message"] == "success", f"查询失败: {result}"
+        assert len(result["data"]) <= 10, f"返回数据超过 limit: {len(result['data'])}"
+        
+        print(f"✅ 向后兼容测试通过: 返回 {len(result['data'])} 条日志")
+    
+    @pytest.mark.asyncio
+    async def test_pagination_with_offset(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试分页功能：使用 offset 参数"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None
+        
+        # 获取第一页（offset=0）
+        result_page1 = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "*",
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 50,
+                "offset": 0,
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert result_page1["message"] == "success", f"第一页查询失败: {result_page1}"
+        page1_data = result_page1["data"]
+        print(f"第 1 页: 返回 {len(page1_data)} 条日志")
+        
+        # 获取第二页（offset=50）
+        result_page2 = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "*",
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 50,
+                "offset": 50,
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert result_page2["message"] == "success", f"第二页查询失败: {result_page2}"
+        page2_data = result_page2["data"]
+        print(f"第 2 页: 返回 {len(page2_data)} 条日志")
+        
+        # 验证两页数据不重复（通过 request_id 字段）
+        if page1_data and page2_data:
+            page1_ids = {log.get("request_id") for log in page1_data if log.get("request_id")}
+            page2_ids = {log.get("request_id") for log in page2_data if log.get("request_id")}
+            overlap = page1_ids & page2_ids
+            assert len(overlap) == 0, f"分页数据重复: {overlap}"
+            print(f"✅ 分页测试通过: 两页数据无重复")
+    
+    @pytest.mark.asyncio
+    async def test_fetch_200_logs_with_pagination(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试完整分页：获取 200 条日志"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None
+        
+        all_logs = []
+        limit = 100
+        target_count = 200
+        
+        for page in range(target_count // limit):
+            offset = page * limit
+            result = await tool.run(
+                {
+                    "project": sls_test_env["project"],
+                    "logStore": sls_test_env["logstore"],
+                    "query": "*",
+                    "from_time": "now-1h",
+                    "to_time": "now",
+                    "limit": limit,
+                    "offset": offset,
+                    "regionId": sls_test_env["region_id"],
+                },
+                context=real_request_context,
+            )
+            
+            assert result["message"] == "success", f"分页 {page + 1} 查询失败: {result}"
+            logs = result["data"]
+            all_logs.extend(logs)
+            print(f"第 {page + 1} 页 (offset={offset}): 返回 {len(logs)} 条")
+            
+            if len(logs) < limit:
+                break
+        
+        print(f"✅ 完整分页测试通过: 共获取 {len(all_logs)} 条日志")
+        assert len(all_logs) >= min(target_count, 250), f"获取日志数量不足: {len(all_logs)}"
+    
+    @pytest.mark.asyncio
+    async def test_reverse_order(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试排序功能：使用 reverse 参数"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None
+        
+        # 升序查询（默认，reverse=False）
+        result_asc = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "*",
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 10,
+                "reverse": False,
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert result_asc["message"] == "success", f"升序查询失败: {result_asc}"
+        asc_data = result_asc["data"]
+        
+        # 降序查询（reverse=True）
+        result_desc = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "*",
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 10,
+                "reverse": True,
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert result_desc["message"] == "success", f"降序查询失败: {result_desc}"
+        desc_data = result_desc["data"]
+        
+        # 验证时间戳顺序
+        if asc_data and desc_data:
+            asc_times = [int(log.get("__time__", 0)) for log in asc_data]
+            desc_times = [int(log.get("__time__", 0)) for log in desc_data]
+            
+            # 升序：第一条时间 <= 最后一条时间
+            if len(asc_times) > 1:
+                assert asc_times[0] <= asc_times[-1], f"升序验证失败: {asc_times[0]} > {asc_times[-1]}"
+            
+            # 降序：第一条时间 >= 最后一条时间
+            if len(desc_times) > 1:
+                assert desc_times[0] >= desc_times[-1], f"降序验证失败: {desc_times[0]} < {desc_times[-1]}"
+            
+            print(f"✅ 排序测试通过: 升序首条时间={asc_times[0] if asc_times else 'N/A'}, 降序首条时间={desc_times[0] if desc_times else 'N/A'}")
+    
+    @pytest.mark.asyncio
+    async def test_combined_offset_and_reverse(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试组合使用：offset + reverse"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None
+        
+        result = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "*",
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 50,
+                "offset": 50,
+                "reverse": True,
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert "data" in result, f"响应缺少 data 字段: {result}"
+        assert result["message"] == "success", f"组合查询失败: {result}"
+        
+        print(f"✅ 组合参数测试通过: 返回 {len(result['data'])} 条日志 (offset=50, reverse=True)")
+    
+    @pytest.mark.asyncio
+    async def test_edge_case_offset_zero(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试边界条件：offset=0"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None
+        
+        result = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "*",
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 1,
+                "offset": 0,
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert result["message"] == "success", f"边界条件查询失败: {result}"
+        assert len(result["data"]) == 1, f"应返回 1 条日志: {len(result['data'])}"
+        
+        print(f"✅ 边界条件测试通过: offset=0, limit=1")
+    
+    @pytest.mark.asyncio
+    async def test_sql_analytics_query(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试 SQL 分析语句（offset 和 reverse 对分析语句无效）"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None
+        
+        # SQL 分析语句
+        result = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "logStore": sls_test_env["logstore"],
+                "query": "* | SELECT level, COUNT(*) as count GROUP BY level",
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 100,
+                "offset": 0,  # 对 SQL 分析无效
+                "regionId": sls_test_env["region_id"],
+            },
+            context=real_request_context,
+        )
+        
+        assert "data" in result, f"响应缺少 data 字段: {result}"
+        # SQL 分析可能返回空结果（如果没有匹配的日志）
+        if result["message"] == "success":
+            print(f"✅ SQL 分析测试通过: 返回 {len(result['data'])} 条聚合结果")
+        else:
+            print(f"⚠️ SQL 分析返回: {result['message']}")
+
+
+class TestSlsListProjectsIntegration:
+    """sls_list_projects 接口集成测试"""
+    
+    @pytest.mark.asyncio
+    async def test_list_projects(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试列出项目"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_list_projects")
+        assert tool is not None, "sls_list_projects 工具未找到"
+        
+        result = await tool.run(
+            {
+                "regionId": sls_test_env["region_id"],
+                "limit": 50,
+            },
+            context=real_request_context,
+        )
+        
+        assert "projects" in result, f"响应缺少 projects 字段: {result}"
+        
+        # 验证测试项目存在
+        project_names = [p.get("project_name") for p in result["projects"]]
+        assert sls_test_env["project"] in project_names, f"测试项目未找到: {sls_test_env['project']}"
+        
+        print(f"✅ 列出项目测试通过: 找到 {len(result['projects'])} 个项目")
+
+
+class TestSlsListLogstoresIntegration:
+    """sls_list_logstores 接口集成测试"""
+    
+    @pytest.mark.asyncio
+    async def test_list_logstores(
+        self,
+        real_mcp_server: FastMCP,
+        real_request_context: Context,
+        sls_test_env: dict,
+    ):
+        """测试列出日志库"""
+        tool = real_mcp_server._tool_manager.get_tool("sls_list_logstores")
+        assert tool is not None, "sls_list_logstores 工具未找到"
+        
+        result = await tool.run(
+            {
+                "project": sls_test_env["project"],
+                "regionId": sls_test_env["region_id"],
+                "limit": 50,
+                "isMetricStore": False,
+            },
+            context=real_request_context,
+        )
+        
+        assert "logstores" in result, f"响应缺少 logstores 字段: {result}"
+        
+        # 验证测试日志库存在
+        assert sls_test_env["logstore"] in result["logstores"], f"测试日志库未找到: {sls_test_env['logstore']}"
+        
+        print(f"✅ 列出日志库测试通过: 找到 {len(result['logstores'])} 个日志库")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s", "--tb=short"])

--- a/tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_toolkit.py
+++ b/tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_toolkit.py
@@ -5,6 +5,8 @@
 - PromQL查询执行  
 - 项目和日志库列表
 - 时间参数处理
+
+注意：这些测试需要真实的阿里云凭证，属于集成测试。
 """
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,6 +22,15 @@ from mcp_server_aliyun_observability.utils import SLSClientWrapper, CredentialWr
 
 
 dotenv.load_dotenv()
+
+# 标记所有测试为集成测试（需要真实阿里云凭证）
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+        reason="需要设置 ALIBABA_CLOUD_ACCESS_KEY_ID 环境变量才能运行"
+    ),
+]
 
 # 测试常量
 TEST_PROJECT = "test-project"
@@ -156,6 +167,54 @@ class TestIaaSToolkit:
         assert "data" in result
         assert "message" in result
         assert len(result["data"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_with_pagination(self, mcp_server: FastMCP, mock_request_context: Context):
+        """测试SQL执行功能 - 分页参数 offset 和 reverse"""
+        tool = mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None, "sls_execute_sql 工具未找到"
+        
+        # 测试使用 offset 和 reverse 参数
+        result = await tool.run(
+            {
+                "project": TEST_PROJECT,
+                "logStore": TEST_LOGSTORE,
+                "query": "*",  # 纯查询语句，非 SQL 分析
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 100,
+                "offset": 100,  # 从第100条开始
+                "reverse": True,  # 降序返回
+                "regionId": TEST_REGION,
+            },
+            context=mock_request_context,
+        )
+        
+        assert "data" in result
+        assert "message" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_backward_compatible(self, mcp_server: FastMCP, mock_request_context: Context):
+        """测试SQL执行功能 - 向后兼容，不传 offset 和 reverse 参数"""
+        tool = mcp_server._tool_manager.get_tool("sls_execute_sql")
+        assert tool is not None, "sls_execute_sql 工具未找到"
+        
+        # 测试不传递 offset 和 reverse 参数（向后兼容）
+        result = await tool.run(
+            {
+                "project": TEST_PROJECT,
+                "logStore": TEST_LOGSTORE,
+                "query": TEST_SQL_QUERY,
+                "from_time": "now-1h",
+                "to_time": "now",
+                "limit": 10,
+                "regionId": TEST_REGION,
+            },
+            context=mock_request_context,
+        )
+        
+        assert "data" in result
+        assert "message" in result
     
     @pytest.mark.asyncio
     async def test_execute_promql_with_time_params(self, mcp_server: FastMCP, mock_request_context: Context):

--- a/tests/mcp_server_aliyun_observability/toolkits/paas/test_paas_data_toolkit.py
+++ b/tests/mcp_server_aliyun_observability/toolkits/paas/test_paas_data_toolkit.py
@@ -1,3 +1,7 @@
+"""PaaS Data Toolkit 测试用例
+
+注意：这些测试需要真实的阿里云凭证，属于集成测试。
+"""
 import os
 
 import dotenv
@@ -13,6 +17,15 @@ from mcp_server_aliyun_observability.toolkits.shared.toolkit import (
 from mcp_server_aliyun_observability.utils import CMSClientWrapper, CredentialWrapper
 
 dotenv.load_dotenv()
+
+# 标记所有测试为集成测试（需要真实阿里云凭证）
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID") and not os.getenv("ALIYUN_ACCESS_KEY_ID"),
+        reason="需要设置 ALIBABA_CLOUD_ACCESS_KEY_ID 或 ALIYUN_ACCESS_KEY_ID 环境变量才能运行"
+    ),
+]
 
 import logging
 

--- a/tests/mcp_server_aliyun_observability/toolkits/paas/test_paas_dataset_toolkit.py
+++ b/tests/mcp_server_aliyun_observability/toolkits/paas/test_paas_dataset_toolkit.py
@@ -1,3 +1,7 @@
+"""PaaS Dataset Toolkit 测试用例
+
+注意：这些测试需要真实的阿里云凭证，属于集成测试。
+"""
 import logging
 import os
 import sys
@@ -16,6 +20,15 @@ from mcp_server_aliyun_observability.utils import CMSClientWrapper, CredentialWr
 
 logger = logging.getLogger(__name__)
 dotenv.load_dotenv()
+
+# 标记所有测试为集成测试（需要真实阿里云凭证）
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID") and not os.getenv("ALIYUN_ACCESS_KEY_ID"),
+        reason="需要设置 ALIBABA_CLOUD_ACCESS_KEY_ID 或 ALIYUN_ACCESS_KEY_ID 环境变量才能运行"
+    ),
+]
 
 
 def check_credentials_and_result(result):

--- a/tests/mcp_server_aliyun_observability/toolkits/paas/test_paas_entity_toolkit.py
+++ b/tests/mcp_server_aliyun_observability/toolkits/paas/test_paas_entity_toolkit.py
@@ -1,3 +1,7 @@
+"""PaaS Entity Toolkit 测试用例
+
+注意：这些测试需要真实的阿里云凭证，属于集成测试。
+"""
 import os
 import sys
 
@@ -19,6 +23,15 @@ from mcp_server_aliyun_observability.toolkits.shared.toolkit import (
 from mcp_server_aliyun_observability.utils import CMSClientWrapper, CredentialWrapper
 
 dotenv.load_dotenv()
+
+# 标记所有测试为集成测试（需要真实阿里云凭证）
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID") and not os.getenv("ALIYUN_ACCESS_KEY_ID"),
+        reason="需要设置 ALIBABA_CLOUD_ACCESS_KEY_ID 或 ALIYUN_ACCESS_KEY_ID 环境变量才能运行"
+    ),
+]
 
 import logging
 


### PR DESCRIPTION
## 描述
### 背景
当前 sls_execute_sql 接口仅支持 limit 参数（最大 100），缺少 offset 分页能力，导致无法获取超过 100 条的完整日志数据。  
根据阿里云官方 GetLogs API 文档，接口支持 offset 和 reverse 参数。

### 改动内容
1. 功能增强
- sls_execute_sql 新增参数：  

| 参数 | 类型 | 默认值 | 说明 |
|------|------|--------|------|
| offset | int | 0 | 查询开始行，用于分页查询 |
| reverse | bool | False | 是否按时间戳降序返回 |

- 向后兼容：新参数均为可选，现有调用无需修改

2. 测试框架完善
- 新增 SLS 集成测试框架（`conftest.py`）
  - 自动创建测试 Project、Logstore、索引
  - 写入 250 条测试日志数据
  - 测试完成后自动清理资源
- 新增集成测试用例（`test_iaas_integration.py`）
  - 分页查询测试
  - 200 条日志完整获取测试
  - 排序功能测试
  - 向后兼容性测试
- 为所有依赖真实凭证的测试添加 `@pytest.mark.integration` 标记

3. 文档更新
- README.md：更新接口参数说明
- CONTRIBUTION.md：完善测试指引
- CHANGELOG.md：记录版本更新

### 改动文件

文件 | 改动类型 | 说明
-- | -- | --
src/.../toolkits/iaas/toolkit.py | 修改 | 新增 offset/reverse 参数
README.md | 修改 | 更新接口文档
CONTRIBUTION.md | 修改 | 完善测试指引
CHANGELOG.md | 修改 | 添加 1.0.5 版本记录
pytest.ini | 修改 | 添加 integration marker
tests/.../iaas/conftest.py | 新增 | SLS 测试环境 fixture
tests/.../iaas/test_iaas_integration.py | 新增 | 集成测试用例
tests/.../iaas/test_iaas_toolkit.py | 修改 | 添加 integration 标记
tests/.../paas/test_paas_*.py | 修改 | 添加 integration 标记

### 测试验证
```
# 单元测试（不需要凭证）
pytest tests/ -m "not integration" -v
# 结果：3 passed

# 集成测试（需要凭证）
export ALIBABA_CLOUD_ACCESS_KEY_ID="xxx"
export ALIBABA_CLOUD_ACCESS_KEY_SECRET="xxx"
pytest tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_integration.py -v -s
# 结果：7 passed
# 单元测试（不需要凭证）pytest tests/ -m "not integration" -v# 结果：3 passed# 集成测试（需要凭证）export ALIBABA_CLOUD_ACCESS_KEY_ID="xxx"export ALIBABA_CLOUD_ACCESS_KEY_SECRET="xxx"pytest tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_integration.py -v -s# 结果：7 passed
```

### 使用示例
```
# 分页获取 200 条日志
for page in range(2):
    result = sls_execute_sql(
        project="my-project",
        logStore="my-logstore",
        query="*",
        from_time="now-1h",
        to_time="now",
        limit=100,
        offset=page * 100,  # 新增
        reverse=True,        # 新增
        regionId="cn-hangzhou"
    )
```

### 检查清单
- [x] 单元测试通过
- [x] 集成测试通过
- [x] 向后兼容验证
- [x] 文档更新
- [x] CHANGELOG 更新