### PR TITLE
feat:新增MCP方法：sls_get_context_logs,查询指定日志前（上文）后（下文）的若干条日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # 版本更新
 
+## 1.0.6 (2026-01-19)
+### 新功能
+- 新增 `sls_get_context_logs` 工具：基于 `pack_id` / `pack_meta` 查询起始日志上下文（上文/下文）日志
+  - 支持 `back_lines` / `forward_lines`（0~100），且至少一个大于 0
+  - 返回结构与 SLS OpenAPI `GetContextLogs` 保持一致（包含 `total_lines/back_lines/forward_lines/progress/logs` 等）
+
+### 文档更新
+- 补充上下文日志的 pack 信息获取说明：通过 `sls_execute_sql` 查询语句追加 `|with_pack_meta` 获取 `__tag__:__pack_id__` 与 `__pack_meta__`
+
+### 测试改进
+- 新增 `sls_get_context_logs` 的真实调用测试方法（在 `test_iaas_toolkit.py` 内），并支持通过 `__main__` + 环境变量选择性运行与打印入参/出参
+
 ## 1.0.5 (2026-01-13)
 ### 新功能
 - `sls_execute_sql` 工具新增分页查询支持

--- a/src/mcp_server_aliyun_observability/toolkits/iaas/toolkit.py
+++ b/src/mcp_server_aliyun_observability/toolkits/iaas/toolkit.py
@@ -7,6 +7,8 @@ from alibabacloud_sls20201230.client import Client as SLSClient
 from alibabacloud_sls20201230.models import (
     CallAiToolsRequest,
     CallAiToolsResponse,
+    GetContextLogsRequest,
+    GetContextLogsResponse,
     GetHistogramsRequest,
     GetHistogramsResponse,
     GetLogsRequest,
@@ -36,6 +38,7 @@ class IaaSToolkit:
     Provides basic infrastructure tools for SLS database query operations:
     - sls_text_to_sql: Convert natural language to SQL queries
     - sls_execute_sql: Execute SQL queries against SLS
+    - sls_get_context_logs: Query context logs around an anchor log
     - cms_execute_promql: Execute PromQL queries against CMS
     - sls_execute_spl: Execute raw SPL queries
     - sls_list_projects: List SLS projects in a region
@@ -317,6 +320,99 @@ class IaaSToolkit:
             return {
                 "data": response_body,
                 "message": "success" if response_body else "No data found",
+            }
+
+        @self.server.tool()
+        @retry(
+            stop=stop_after_attempt(Config.get_retry_attempts()),
+            wait=wait_fixed(Config.RETRY_WAIT_SECONDS),
+            retry=retry_if_exception_type(Exception),
+            reraise=True,
+        )
+        @handle_tea_exception
+        def sls_get_context_logs(
+            ctx: Context,
+            project: str = Field(..., description="sls project name"),
+            logStore: str = Field(..., description="sls log store name"),
+            pack_id: str = Field(..., description="pack_id of the anchor log"),
+            pack_meta: str = Field(..., description="pack_meta of the anchor log"),
+            back_lines: int = Field(
+                10, description="lines before anchor log, range 0-100", ge=0, le=100
+            ),
+            forward_lines: int = Field(
+                10, description="lines after anchor log, range 0-100", ge=0, le=100
+            ),
+            regionId: str = Field(
+                default=...,
+                description="aliyun region id,region id format like 'xx-xxx',like 'cn-hangzhou'",
+            ),
+        ) -> Dict[str, Any]:
+            """查询指定日志前后的上下文日志。
+
+            ## 功能概述
+
+            该工具用于根据“起始日志”的 pack_id 与 pack_meta，查询该日志前（上文）后（下文）的若干条上下文日志。
+
+            说明：上下文查询的时间范围固定为起始日志的前后一天（由SLS服务端限制）。
+
+            ## 如何获取 pack_id 与 pack_meta（推荐方式）
+
+            先使用本项目的 `sls_execute_sql` 获取目标日志，并在查询语句末尾追加 `|with_pack_meta`，
+            使查询结果携带内部字段：
+            - `__pack_id__`：对应本工具的 pack_id
+            - `__pack_meta__`：对应本工具的 pack_meta
+
+            然后选定你要作为起始点的那条日志，将上述两个字段值传入本工具即可。
+
+            ## 参数说明
+
+            - back_lines / forward_lines：范围 0~100，且两者至少一个大于 0。
+
+            ## 返回结果
+
+            返回结构与SLS OpenAPI一致（包含 total_lines/back_lines/forward_lines/progress/logs 等），
+            其中 logs 内每条日志会包含：
+            - `__index_number__`：相对起始日志的位置（负数为上文，0 为起始日志，正数为下文）
+            - `__tag__:__pack_id__` 与 `__pack_meta__`：可作为下一次上下文查询的定位信息
+            """
+            if back_lines == 0 and forward_lines == 0:
+                return {
+                    "data": None,
+                    "message": "back_lines 与 forward_lines 不能同时为 0，至少一个需要大于 0",
+                }
+
+            sls_client: SLSClient = ctx.request_context.lifespan_context[
+                "sls_client"
+            ].with_region(regionId)
+
+            request: GetContextLogsRequest = GetContextLogsRequest(
+                pack_id=pack_id,
+                pack_meta=pack_meta,
+                back_lines=back_lines,
+                forward_lines=forward_lines,
+            )
+
+            runtime: util_models.RuntimeOptions = util_models.RuntimeOptions()
+            runtime.read_timeout = 60000
+            runtime.connect_timeout = 60000
+
+            response: GetContextLogsResponse = sls_client.get_context_logs_with_options(
+                project, logStore, request, headers={}, runtime=runtime
+            )
+
+            response_body: Any = response.body
+            if hasattr(response_body, "to_map"):
+                response_body = response_body.to_map()
+
+            logs: Any = None
+            if isinstance(response_body, dict):
+                logs = response_body.get("logs")
+            else:
+                logs = getattr(response_body, "logs", None)
+
+            return {
+                "data": response_body,
+                "message": "success" if logs else "No data found",
             }
 
         @self.server.tool()
@@ -696,7 +792,7 @@ class IaaSToolkit:
                 description="sls project name, must exact match, should not contain chinese characters",
             ),
             logStore: str = Field(
-                ..., 
+                ...,
                 description="sls log store name, must exact match, should not contain chinese characters"
             ),
             from_time: Union[str, int] = Field(
@@ -706,7 +802,7 @@ class IaaSToolkit:
                 "now", description="结束时间: Unix时间戳(秒/毫秒)或相对时间(now)"
             ),
             regionId: str = Field(
-                ..., 
+                ...,
                 description="Region ID"
             ),
             logField: str = Field(
@@ -751,7 +847,7 @@ class IaaSToolkit:
             Returns:
                 日志数据概览信息
             """
-            
+
             sls_client: SLSClient = ctx.request_context.lifespan_context[
                 "sls_client"
             ].with_region(regionId)
@@ -763,7 +859,7 @@ class IaaSToolkit:
 
             from_timestamp = TimeRangeParser.parse_time_expression(from_time)
             to_timestamp = TimeRangeParser.parse_time_expression(to_time)
-            
+
             # 1) get total number of log records in the specified time range
             request: GetHistogramsRequest = GetHistogramsRequest(
                 from_=from_timestamp,
@@ -771,8 +867,8 @@ class IaaSToolkit:
                 query=None if not filter_query else filter_query
             )
             response: GetHistogramsResponse = sls_client.get_histograms(
-                project=project, 
-                logstore=logStore, 
+                project=project,
+                logstore=logStore,
                 request=request
             )
             histograms = response.body
@@ -838,7 +934,7 @@ class IaaSToolkit:
                     "patterns": [],
                     "message": f"Failed to do log explore because pattern model creation failed: {error_msg}"
                 }
-            
+
             # 3) use model to match log data
             sampling_rate = int(200000 / total_count * 100)
             sampling_rate = min(max(sampling_rate, 1), 100)
@@ -932,7 +1028,7 @@ class IaaSToolkit:
                     variables.append(var_info)
                 formatted_item["variables"] = variables
                 return formatted_item
-            
+
             results = [format_result(item) for item in response.body]
             return {
                 "patterns": results,
@@ -954,7 +1050,7 @@ class IaaSToolkit:
                 description="sls project name, must exact match, should not contain chinese characters",
             ),
             logStore: str = Field(
-                ..., 
+                ...,
                 description="sls log store name, must exact match, should not contain chinese characters"
             ),
             test_from_time: Union[str, int] = Field(
@@ -970,7 +1066,7 @@ class IaaSToolkit:
                 "now", description="对照组数据的结束时间: Unix时间戳(秒/毫秒)或相对时间(now)"
             ),
             regionId: str = Field(
-                ..., 
+                ...,
                 description="Region ID"
             ),
             logField: str = Field(
@@ -1045,8 +1141,8 @@ class IaaSToolkit:
                 query=None if not filter_query else filter_query
             )
             response: GetHistogramsResponse = sls_client.get_histograms(
-                project=project, 
-                logstore=logStore, 
+                project=project,
+                logstore=logStore,
                 request=request
             )
             histograms = response.body
@@ -1256,7 +1352,7 @@ class IaaSToolkit:
                     variables.append(var_info)
                 formatted_item["variables"] = variables
                 return formatted_item
-            
+
             pairs: Dict[Tuple[str, str], Dict] = {}
             for item in response.body:
                 formatted_item = format_result(item)
@@ -1264,7 +1360,7 @@ class IaaSToolkit:
                 if key not in pairs:
                     pairs[key] = {}
                 pairs[key][formatted_item["test_or_control"]] = formatted_item
-            
+
             def merge_items(test: Optional[Dict] = None, control: Optional[Dict] = None) -> Optional[Dict]:
                 if not test and not control:
                     return None
@@ -1278,7 +1374,7 @@ class IaaSToolkit:
                     "test_variables": [] if not test else test["variables"],
                     "control_variables": [] if not control else control["variables"]
                 }
-            
+
             results: List[Dict] = []
             for pair in pairs.values():
                 merged_item = merge_items(pair.get("test"), pair.get("control"))

--- a/tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_toolkit.py
+++ b/tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_toolkit.py
@@ -9,6 +9,7 @@
 注意：这些测试需要真实的阿里云凭证，属于集成测试。
 """
 import os
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import dotenv
@@ -44,6 +45,13 @@ LOG_EXPLORE_PROJECT = "sls-ml-spl-shanghai-cloudspe"
 LOG_EXPLORE_LOGSTORE = "massive-hdfs-log"
 LOG_EXPLORE_REGION = "cn-shanghai"
 
+
+# log explore and log compare test data
+LOG_EXPLORE_PROJECT1 = "testdevcomb"
+LOG_EXPLORE_LOGSTORE1 = "stable-v3"
+LOG_EXPLORE_REGION1 = "cn-shenzhen"
+SLS_CONTEXT_PACK_ID = "9DC3C950CF9A40FD-D"
+SLS_CONTEXT_PACK_META = "1|MTc2ODI0MzgzNzc0OTczMDkxNQ==|1223|383"
 @pytest.fixture
 def mock_request_context():
     # """模拟请求上下文"""
@@ -368,5 +376,31 @@ class TestIaaSToolkit:
         print (f"len(result['patterns']): {len(result['patterns'])}")
         print (result["patterns"][2])
 
+    @pytest.mark.asyncio
+    async def test_sls_get_context_logs(self, mcp_server: FastMCP, mock_request_context: Context):
+        tool = mcp_server._tool_manager.get_tool("sls_get_context_logs")
+        assert tool is not None, "sls_get_context_logs 工具未找到"
+
+        tool_input = {
+            "project": LOG_EXPLORE_PROJECT1,
+            "logStore": LOG_EXPLORE_LOGSTORE1,
+            "pack_id": SLS_CONTEXT_PACK_ID,
+            "pack_meta": SLS_CONTEXT_PACK_META,
+            "back_lines": int(os.getenv("SLS_CONTEXT_BACK_LINES", "10")),
+            "forward_lines": int(os.getenv("SLS_CONTEXT_FORWARD_LINES", "10")),
+            "regionId": LOG_EXPLORE_REGION1,
+        }
+        print("\n[sls_get_context_logs] input:")
+        print(json.dumps(tool_input, ensure_ascii=False, indent=2))
+
+        result = await tool.run(tool_input, context=mock_request_context)
+
+        print("\n[sls_get_context_logs] output:")
+        print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+
+        assert "message" in result
+        assert "data" in result
+
 if __name__ == "__main__":
-    pytest.main([__file__, "-s", "-v", "-k" "test_log_explore"])
+    # pytest.main([__file__, "-s", "-v", "-k" "test_log_explore"])
+    pytest.main([__file__, "-s", "-v", "-ktest_sls_get_context_logs"])


### PR DESCRIPTION

## 描述

### 背景
当前 IaaS 工具集缺少“上下文日志”查询能力：在定位到某条关键日志（anchor log）后，无法直接拉取该日志前后（上文/下文）的日志上下文，导致排障时需要手动扩大时间范围、反复查询，效率较低。  
根据阿里云 SLS 官方 `GetContextLogs` API，服务端支持通过 `pack_id` / `pack_meta` 精确查询上下文日志。

---

## 改动内容

### 功能增强
新增 `sls_get_context_logs` 工具：
- 入参：
  - `project` / `logStore` / `regionId`
  - `pack_id`：起始日志定位信息
  - `pack_meta`：起始日志定位信息
  - `back_lines` / `forward_lines`：上下文行数（0~100，且至少一个 > 0）
- 出参：
  - `data`：与 SLS OpenAPI `GetContextLogs` 返回结构一致（包含 `total_lines/back_lines/forward_lines/progress/logs` 等）
  - `message`：`success` / `No data found` / 参数校验提示

### 文档补充
补充 `pack_id` / `pack_meta` 的获取方式说明：
- 通过 `sls_execute_sql` 在查询语句末尾追加 `|with_pack_meta`，即可在结果中获得：
  - `__tag__:__pack_id__` → 对应 `pack_id`
  - `__pack_meta__` → 对应 `pack_meta`

### 测试改进
在现有 `tests/.../iaas/test_iaas_toolkit.py` 中新增真实调用测试方法（不 mock）：
- `test_sls_get_context_logs`
- 从环境变量读取 `project/logStore/regionId/pack_id/pack_meta` 等入参
- 使用 `-s` 时在终端打印入参/出参，方便人工验证
- 支持在 `__main__` 中通过 `TEST_TARGET=sls_get_context_logs` 选择性运行该用例

---

## 改动文件

| 文件 | 改动类型 | 说明 |
|---|---|---|
| `src/mcp_server_aliyun_observability/toolkits/iaas/toolkit.py` | 修改 | 新增 `sls_get_context_logs` 工具实现与说明 |
| `tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_toolkit.py` | 修改 | 新增 `test_sls_get_context_logs` 真实测试方法，并调整 `__main__` 支持选择性运行 |
| `CHANGELOG.md` | 修改 | 新增 `1.0.6` 版本记录，包含工具、说明与测试变更 |

---

## 测试验证

### 单元/本地运行（无凭证会跳过集成）
- 运行 `test_sls_get_context_logs` 需要真实凭证 + 上下文入参环境变量，否则会 `skip`（符合预期）。

### 单元测试（需要凭证）
环境变量示例：
```bash
export ALIBABA_CLOUD_ACCESS_KEY_ID="xxx"
export ALIBABA_CLOUD_ACCESS_KEY_SECRET="xxx"
export SLS_CONTEXT_REGION_ID="cn-hangzhou"

```

常量示例：
```bash
LOG_EXPLORE_PROJECT1 = "testdevcomb"
LOG_EXPLORE_LOGSTORE1 = "stable-v3"
LOG_EXPLORE_REGION1 = "cn-shenzhen"
SLS_CONTEXT_PACK_ID = "9DC3C950CF9A40FD-D"
SLS_CONTEXT_PACK_META = "1|MTc2ODI0MzgzNzc0OTczMDkxNQ==|1223|383"
```

执行（会在终端打印入参/出参）：
```bash
python tests/mcp_server_aliyun_observability/toolkits/iaas/test_iaas_toolkit.py
```

---

## 使用示例

### 方式一：推荐（先获取 pack 信息，再查上下文）
1) 获取 `pack_id/pack_meta`（追加 `|with_pack_meta`）：
```python
result = sls_execute_sql(
    project="my-project",
    logStore="my-logstore",
    query="* |with_pack_meta",
    from_time="now-15m",
    to_time="now",
    limit=1,
    regionId="cn-hangzhou",
)
pack_id = result["data"][0]["__tag__:__pack_id__"]
pack_meta = result["data"][0]["__pack_meta__"]
```

2) 查询上下文日志：
```python
ctx_logs = sls_get_context_logs(
    project="my-project",
    logStore="my-logstore",
    pack_id=pack_id,
    pack_meta=pack_meta,
    back_lines=20,
    forward_lines=20,
    regionId="cn-hangzhou",
)
```

### 方式二：直接测试（本 PR 提供的真实用例方式）
- 把 `SLS_CONTEXT_*` 环境变量配置好后运行 `python test_iaas_toolkit.py`，终端直接打印入参/出参。

---

## 检查清单
- [ ] 功能自测通过（`sls_get_context_logs` 能返回上下文日志）
- [ ] 参数校验已覆盖（`back_lines` 与 `forward_lines` 不允许同时为 0）
- [ ] 测试用例可运行并可打印入参/出参（`-s`）
- [ ] 文档说明已补充（`|with_pack_meta` 获取 pack 信息）
- [ ] CHANGELOG 已更新（1.0.6）