### PR TITLE
fix: use standard /mcp endpoint path for streamable-http transport

### DIFF
--- a/pkg/server/transport.go
+++ b/pkg/server/transport.go
@@ -133,7 +133,7 @@ func newStreamableHTTPTransport(cfg *config.Config, mcpSrv *mcpserver.MCPServer)
 	}
 
 	srv := mcpserver.NewStreamableHTTPServer(mcpSrv,
-		mcpserver.WithEndpointPath("/streamhttp"),
+		mcpserver.WithEndpointPath("/mcp"),
 		mcpserver.WithStreamableHTTPServer(httpSrv),
 	)
 
@@ -148,7 +148,7 @@ func (t *streamableHTTPTransport) Start(_ context.Context) error {
 	slog.Info("========================================")
 	slog.Info("  MCP Server started successfully!")
 	slog.Info("  Transport: streamable-http")
-	slog.Info("  Endpoint", "url", fmt.Sprintf("http://%s/streamhttp", t.addr))
+	slog.Info("  Endpoint", "url", fmt.Sprintf("http://%s/mcp", t.addr))
 	slog.Info("========================================")
 	return t.srv.Start(t.addr)
 }


### PR DESCRIPTION
## Problem

When using `streamable-http` transport, MCP clients like Codex fail to create threads because the server endpoint was configured as `/streamhttp` instead of the standard `/mcp` path.

See: https://github.com/aliyun/alibabacloud-observability-mcp-server/issues/71

## Solution

Change the streamable-http endpoint path from `/streamhttp` to `/mcp` to align with the MCP specification and ensure compatibility with standard MCP clients.

## Changes

- Updated `WithEndpointPath` from `/streamhttp` to `/mcp` in `pkg/server/transport.go`
- Updated log output to reflect the new endpoint URL

## Testing

- Verified no lint errors after modification
- Endpoint now matches what Codex and other MCP clients expect by default